### PR TITLE
Add slack join redirect

### DIFF
--- a/redirects
+++ b/redirects
@@ -1,3 +1,8 @@
+---
+layout: none
+permalink: _redirects
+---
 /  /de/  301!  Language=de,de-de,de-DE,de_DE
 /  /en/  301   Language=en
 /  /de/  301
+/l/slack {{site.slack_invite_link}} 301


### PR DESCRIPTION
Add a redirect from https://www.makervsvirus.org/l/slack to the most recent slack join url, so we can embed this in other places, like the google forms.