### PR TITLE
Organisation Links: Merge MedPrint+print2protect

### DIFF
--- a/_data/organisations.yml
+++ b/_data/organisations.yml
@@ -3,9 +3,7 @@
 - name: Project Open Air
   link: https://www.projectopenair.org/
 - name: print2protect
-  link: https://info743967.typeform.com/to/o8l610
-- name: MedPrint
-  link: http://medprint.org/
+  link: https://print2protect.org
 - name: Coronavirus Makers - Spain
   link: https://www.coronavirusmakers.org
 - name: 3dk Against Corona


### PR DESCRIPTION
MedPrint and print2protect have merged and are now jointly using the print2protect name as well as the print2protect.org domain